### PR TITLE
feat(cv): add _cv/ Jekyll collection + cv-entry/cv-list layouts + /cv…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,19 @@ google_analytics: 'UA-46278016-1'
 disqus: 'demowebsite'
 mailchimp-list: 'https://wowthemes.us11.list-manage.com/subscribe/post?u=8aeb20a530e124561927d3bd8&amp;id=8c3d2d214b'
 include: ["_pages"]
+
+# CV Collection — Selected Work & Achievements
+collections:
+  cv:
+    output: true
+    permalink: /cv/:name/
+
+defaults:
+  - scope:
+      path: ""
+      type: "cv"
+    values:
+      layout: cv-entry
 permalink: /:title/
 
 # Authors

--- a/_layouts/cv-entry.html
+++ b/_layouts/cv-entry.html
@@ -1,0 +1,106 @@
+---
+layout: default
+---
+
+<div class="container">
+<div class="row">
+<div class="col-md-8 mx-auto">
+
+  <nav aria-label="breadcrumb" class="mb-4">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="{{ site.baseurl }}/">Home</a></li>
+      <li class="breadcrumb-item"><a href="{{ site.baseurl }}/cv/">Selected Work</a></li>
+      <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
+    </ol>
+  </nav>
+
+  <article class="cv-entry">
+
+    <header class="cv-entry__header mb-4">
+      <div class="d-flex align-items-start justify-content-between flex-wrap">
+        <div>
+          <h1 class="cv-entry__title">{{ page.title }}</h1>
+          {% if page.role %}
+          <p class="cv-entry__role text-muted mb-1">{{ page.role }}{% if page.company %} · {{ page.company }}{% endif %}</p>
+          {% endif %}
+          {% if page.period %}
+          <p class="cv-entry__period">
+            <i class="far fa-calendar-alt mr-1"></i>
+            <time>{{ page.period }}</time>
+          </p>
+          {% endif %}
+        </div>
+        <div class="cv-entry__badges mt-2">
+          {% if page.type %}
+          <span class="badge badge-secondary mr-1">{{ page.type }}</span>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if page.skills and page.skills.size > 0 %}
+      <div class="cv-entry__skills mt-3">
+        {% for skill in page.skills %}
+        <span class="badge badge-light border mr-1 mb-1">{{ skill }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </header>
+
+    {% if page.summary %}
+    <div class="cv-entry__summary alert alert-light mb-4">
+      <strong>{{ page.summary }}</strong>
+    </div>
+    {% endif %}
+
+    {% if page.description %}
+    <div class="cv-entry__description mb-4">
+      <p>{{ page.description }}</p>
+    </div>
+    {% endif %}
+
+    {{ content }}
+
+    {% if page.achievements and page.achievements.size > 0 %}
+    <div class="cv-entry__achievements mb-4">
+      <h4>Key Achievements</h4>
+      <ul class="list-group list-group-flush">
+        {% for achievement in page.achievements %}
+        <li class="list-group-item px-0">
+          <i class="fas fa-check-circle text-success mr-2"></i>{{ achievement }}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    {% if page.learnings and page.learnings.size > 0 %}
+    <div class="cv-entry__learnings mb-4">
+      <h4>Key Learnings</h4>
+      <ul class="list-group list-group-flush">
+        {% for learning in page.learnings %}
+        <li class="list-group-item px-0">
+          <i class="fas fa-lightbulb text-warning mr-2"></i>{{ learning }}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
+
+    <footer class="cv-entry__footer mt-5 pt-4 border-top">
+      <a href="{{ site.baseurl }}/cv/" class="btn btn-outline-secondary btn-sm">
+        <i class="fas fa-arrow-left mr-1"></i> Back to Selected Work
+      </a>
+    </footer>
+
+  </article>
+
+</div>
+</div>
+</div>
+
+<style>
+.cv-entry__title { font-size: 1.8rem; font-weight: 700; }
+.cv-entry__role  { font-size: 1rem; }
+.cv-entry__period { font-size: 0.9rem; color: #6c757d; }
+.cv-entry__summary { border-left: 4px solid #343a40; }
+</style>

--- a/_layouts/cv-list.html
+++ b/_layouts/cv-list.html
@@ -1,0 +1,134 @@
+---
+layout: default
+---
+
+<div class="container">
+<div class="row">
+<div class="col-md-10 mx-auto">
+
+  <header class="cv-list__header text-center mb-5">
+    <h1>{{ page.title | default: "Selected Work &amp; Achievements" }}</h1>
+    {% if page.subtitle %}
+    <p class="lead text-muted">{{ page.subtitle }}</p>
+    {% endif %}
+  </header>
+
+  <!-- Filter controls -->
+  <div class="cv-list__filters mb-4" id="cv-filters">
+    <div class="d-flex flex-wrap align-items-center">
+      <span class="mr-2 text-muted small">Filter:</span>
+      <button class="btn btn-sm btn-outline-secondary mr-1 mb-1 cv-filter-btn active" data-filter="all">All</button>
+      {% assign all_types = site.cv | map: "type" | uniq | compact %}
+      {% for type in all_types %}
+      <button class="btn btn-sm btn-outline-secondary mr-1 mb-1 cv-filter-btn" data-filter="{{ type }}">{{ type | capitalize }}</button>
+      {% endfor %}
+    </div>
+    <div class="mt-2">
+      <input type="text" id="cv-search" class="form-control form-control-sm" placeholder="Search by skill or keyword…" style="max-width:300px;">
+    </div>
+  </div>
+
+  <!-- CV entries grid -->
+  <div class="row" id="cv-grid">
+    {% assign cv_entries = site.cv | sort: "date" | reverse %}
+    {% for entry in cv_entries %}
+    <div class="col-md-6 mb-4 cv-card-wrapper"
+         data-type="{{ entry.type }}"
+         data-skills="{{ entry.skills | join: ' ' | downcase }}"
+         data-text="{{ entry.title | downcase }} {{ entry.summary | downcase }} {{ entry.company | downcase }}">
+      <div class="card h-100 shadow-sm cv-card">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start mb-2">
+            <span class="badge badge-secondary">{{ entry.type | default: "project" }}</span>
+            {% if entry.period %}
+            <small class="text-muted">{{ entry.period }}</small>
+            {% endif %}
+          </div>
+          <h5 class="card-title">
+            <a href="{{ entry.url | prepend: site.baseurl }}" class="text-dark text-decoration-none">{{ entry.title }}</a>
+          </h5>
+          {% if entry.role or entry.company %}
+          <p class="card-subtitle text-muted mb-2 small">{{ entry.role }}{% if entry.role and entry.company %} · {% endif %}{{ entry.company }}</p>
+          {% endif %}
+          {% if entry.summary %}
+          <p class="card-text small">{{ entry.summary | truncate: 120 }}</p>
+          {% endif %}
+          {% if entry.skills and entry.skills.size > 0 %}
+          <div class="mt-3">
+            {% for skill in entry.skills limit: 4 %}
+            <span class="badge badge-light border mr-1">{{ skill }}</span>
+            {% endfor %}
+            {% if entry.skills.size > 4 %}
+            <span class="text-muted small">+{{ entry.skills.size | minus: 4 }} more</span>
+            {% endif %}
+          </div>
+          {% endif %}
+        </div>
+        <div class="card-footer bg-transparent border-top-0">
+          <a href="{{ entry.url | prepend: site.baseurl }}" class="btn btn-sm btn-outline-dark">View details →</a>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div id="cv-empty" class="text-center text-muted py-5 d-none">
+    <i class="fas fa-search fa-2x mb-3"></i>
+    <p>No entries match your filter. <a href="#" id="cv-clear">Clear filters</a></p>
+  </div>
+
+</div>
+</div>
+</div>
+
+<script>
+(function() {
+  var filterBtns = document.querySelectorAll('.cv-filter-btn');
+  var search     = document.getElementById('cv-search');
+  var cards      = document.querySelectorAll('.cv-card-wrapper');
+  var empty      = document.getElementById('cv-empty');
+  var clearBtn   = document.getElementById('cv-clear');
+  var activeFilter = 'all';
+
+  function applyFilters() {
+    var q = (search.value || '').toLowerCase().trim();
+    var visible = 0;
+    cards.forEach(function(card) {
+      var typeMatch  = activeFilter === 'all' || card.dataset.type === activeFilter;
+      var skillMatch = !q || (card.dataset.skills + ' ' + card.dataset.text).indexOf(q) !== -1;
+      var show = typeMatch && skillMatch;
+      card.style.display = show ? '' : 'none';
+      if (show) visible++;
+    });
+    empty.classList.toggle('d-none', visible > 0);
+  }
+
+  filterBtns.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      filterBtns.forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      activeFilter = btn.dataset.filter;
+      applyFilters();
+    });
+  });
+
+  search.addEventListener('input', applyFilters);
+
+  if (clearBtn) {
+    clearBtn.addEventListener('click', function(e) {
+      e.preventDefault();
+      search.value = '';
+      activeFilter = 'all';
+      filterBtns.forEach(function(b) { b.classList.remove('active'); });
+      filterBtns[0].classList.add('active');
+      applyFilters();
+    });
+  }
+})();
+</script>
+
+<style>
+.cv-card { transition: box-shadow .15s; }
+.cv-card:hover { box-shadow: 0 4px 15px rgba(0,0,0,.12) !important; }
+.cv-filter-btn.active { background: #343a40; color: #fff; border-color: #343a40; }
+</style>

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -1,0 +1,6 @@
+---
+layout: cv-list
+title: "Selected Work & Achievements"
+subtitle: "Projects, milestones, and skills built since 2018 — from enterprise engineering to indie SaaS."
+permalink: /cv/
+---


### PR DESCRIPTION
…/ page

- _config.yml: add `cv` collection (output: true, permalink /cv/:name/), set default layout cv-entry
- _layouts/cv-entry.html: detail view — title/role/company/period, skills badges, summary callout, achievements/learnings lists, breadcrumb nav
- _layouts/cv-list.html: filterable card grid — type filter buttons, keyword/skill search input, empty-state, inline JS filter controller
- _pages/cv.md: /cv/ permalink pointing at cv-list layout

Companion script: task_executor/scripts/cv_jekyll_publisher.py (in my-obsidian repo — reads cv-entries-current.json, generates _cv/*.md)

https://claude.ai/code/session_01Rwva4VtoUSkCQHtSXaEi4i